### PR TITLE
feat: add Introduce section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/src/assets/MailIcon.tsx
+++ b/src/assets/MailIcon.tsx
@@ -1,4 +1,4 @@
-const Mail = () => {
+const MailIcon = () => {
   return (
     <svg
       width="15"
@@ -17,4 +17,4 @@ const Mail = () => {
   );
 };
 
-export default Mail;
+export default MailIcon;

--- a/src/assets/Mail.tsx
+++ b/src/assets/Mail.tsx
@@ -1,0 +1,20 @@
+const Mail = () => {
+  return (
+    <svg
+      width="15"
+      height="12"
+      viewBox="0 0 16 13"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M13.8805 3.8224V11H0.447632V12.4925H15.373V0.552246H0.447632V9.50747H1.94017V3.82165L7.91027 7.58405L13.8805 3.8224ZM1.94015 2.04476H13.8805V2.05819L7.91065 5.81961L1.94015 2.0567V2.04476Z"
+        fill="#0D0D0D"
+      />
+    </svg>
+  );
+};
+
+export default Mail;

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,12 +1,16 @@
 import styled from '@emotion/styled';
+import Introduce from 'components/introduce/Introduce';
 
 const Container = () => {
-  return <Wrap>Container</Wrap>;
+  return (
+    <Wrap>
+      <Introduce />
+    </Wrap>
+  );
 };
 
 const Wrap = styled.div`
-  color: red;
-  background-color: ${({ theme }) => theme.colors.HIGHTLIGHT};
+  /* background-color: ${({ theme }) => theme.colors.HIGHTLIGHT}; */
 `;
 
 export default Container;

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,16 +1,11 @@
-import styled from '@emotion/styled';
 import Introduce from 'components/introduce/Introduce';
 
 const Container = () => {
   return (
-    <Wrap>
+    <>
       <Introduce />
-    </Wrap>
+    </>
   );
 };
-
-const Wrap = styled.div`
-  /* background-color: ${({ theme }) => theme.colors.HIGHTLIGHT}; */
-`;
 
 export default Container;

--- a/src/components/common/Divider.tsx
+++ b/src/components/common/Divider.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+interface DividerProps {
+  height?: number;
+  margin?: number;
+}
+
+const Divider = ({ height = 2, margin = 60 }: DividerProps) => {
+  return (
+    <Stroke
+      height={height}
+      margin={margin}
+    />
+  );
+};
+
+const Stroke = styled.div<{ height: number; margin: number }>`
+  width: 100%;
+  height: ${(props) => props.height + 'px'};
+  margin-bottom: ${(props) => props.margin + 'px'};
+  background-color: ${({ theme }) => theme.colors.SUB_FONT};
+`;
+
+export default Divider;

--- a/src/components/common/InfoCard.tsx
+++ b/src/components/common/InfoCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+import Divider from 'components/common/Divider';
+import 'styles/fonts/Berbas.css';
+
+interface InfoCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+const InfoCard = ({ title, children }: InfoCardProps) => {
+  return (
+    <>
+      <Divider />
+      <Wrap>
+        <Title>{title}</Title>
+        <article>{children}</article>
+      </Wrap>
+    </>
+  );
+};
+
+const Wrap = styled.section`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+`;
+
+const Title = styled.h2`
+  font-family: 'Bebas Neue', cursive;
+  font-size: 3rem;
+  color: ${({ theme }) => theme.colors.MAIN_FONT};
+`;
+
+export default InfoCard;

--- a/src/components/common/StackButton.tsx
+++ b/src/components/common/StackButton.tsx
@@ -9,15 +9,13 @@ interface StackButtonProps {
 
 const StackButton = ({ children, url }: StackButtonProps) => {
   return (
-    <Border>
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {children}
-      </a>
-    </Border>
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Border>{children}</Border>
+    </a>
   );
 };
 

--- a/src/components/common/StackButton.tsx
+++ b/src/components/common/StackButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+interface StackButtonProps {
+  children: React.ReactNode;
+  url?: string;
+}
+
+const StackButton = ({ children, url }: StackButtonProps) => {
+  return (
+    <Border>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    </Border>
+  );
+};
+
+const Border = styled.li`
+  padding: 0.4rem 0.6rem;
+  border: 1.5px solid ${({ theme }) => theme.colors.MAIN_FONT};
+  border-radius: 2.3rem;
+
+  :hover {
+    border: 1.5px solid ${({ theme }) => theme.colors.HIGHTLIGHT};
+    background-color: ${({ theme }) => theme.colors.HIGHTLIGHT};
+    color: ${({ theme }) => theme.colors.BACKGROUND};
+  }
+`;
+
+export default StackButton;

--- a/src/components/introduce/IntroContents.tsx
+++ b/src/components/introduce/IntroContents.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import Mail from 'assets/Mail';
+import StackButton from 'components/common/StackButton';
+
+import INTRODUCE_DATA from './introduceData';
+
+const IntroContents = () => {
+  return (
+    <Wrap>
+      <Title>{INTRODUCE_DATA.title}</Title>
+      <Contents>{INTRODUCE_DATA.contnets}</Contents>
+      <Contact>
+        <li>
+          <Mail />
+        </li>
+        <li>{INTRODUCE_DATA.contact}</li>
+      </Contact>
+      <Resume>
+        {INTRODUCE_DATA.resume.map((resume, index) => {
+          return <StackButton url={resume.url}>{resume.title}</StackButton>;
+        })}
+      </Resume>
+    </Wrap>
+  );
+};
+
+const Wrap = styled.div`
+  width: 600px;
+  color: ${({ theme }) => theme.colors.MAIN_FONT};
+`;
+
+const Title = styled.h3`
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+`;
+
+const Contents = styled.p`
+  margin-bottom: 1.4rem;
+  font-size: 1rem;
+  line-height: 1.4rem;
+  white-space: normal;
+`;
+
+const Contact = styled.ul`
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 1.4rem;
+  font-size: 1.1rem;
+`;
+
+const Resume = styled.ul`
+  display: flex;
+  gap: 14px;
+`;
+
+export default IntroContents;

--- a/src/components/introduce/IntroContents.tsx
+++ b/src/components/introduce/IntroContents.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import Mail from 'assets/Mail';
+import MailIcon from 'assets/\bMailIcon';
 import StackButton from 'components/common/StackButton';
 
 import INTRODUCE_DATA from './introduceData';
@@ -11,7 +11,7 @@ const IntroContents = () => {
       <Contents>{INTRODUCE_DATA.contnets}</Contents>
       <Contact>
         <li>
-          <Mail />
+          <MailIcon />
         </li>
         <li>{INTRODUCE_DATA.contact}</li>
       </Contact>

--- a/src/components/introduce/IntroContents.tsx
+++ b/src/components/introduce/IntroContents.tsx
@@ -16,8 +16,15 @@ const IntroContents = () => {
         <li>{INTRODUCE_DATA.contact}</li>
       </Contact>
       <Resume>
-        {INTRODUCE_DATA.resume.map((resume, index) => {
-          return <StackButton url={resume.url}>{resume.title}</StackButton>;
+        {INTRODUCE_DATA.resume.map((resume) => {
+          return (
+            <StackButton
+              key={resume.title}
+              url={resume.url}
+            >
+              {resume.title}
+            </StackButton>
+          );
         })}
       </Resume>
     </Wrap>

--- a/src/components/introduce/Introduce.tsx
+++ b/src/components/introduce/Introduce.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import InfoCard from 'components/common/InfoCard';
+import IntroContents from 'components/introduce/IntroContents';
+
+const Introduce = () => {
+  return (
+    <InfoCard title="INTRODUCE">
+      <IntroContents />
+    </InfoCard>
+  );
+};
+
+export default Introduce;

--- a/src/components/introduce/introduceData.ts
+++ b/src/components/introduce/introduceData.ts
@@ -1,0 +1,13 @@
+const INTRODUCE_DATA = {
+  title: '안녕하세요',
+  contnets:
+    '전공으로 컴퓨터 공학을 공부하고 현재는 웹 개발 분야에서 경력을 쌓고 있습니다.전공으로 컴퓨터 공학을 공부하고 현재는 웹 개발 분야에서 경력을 쌓고 있습니다. 전공으로 컴퓨터 공학을 공부하고 현재는 웹 개발 분야에서 경력을 쌓고 있습니다.',
+  contact: 'whoareyou.gmail.com',
+  resume: [
+    { title: 'github', url: 'https://github.com/' },
+    { title: 'LinkedIn', url: 'https://github.com/' },
+    { title: 'Instagram', url: 'https://github.com/' },
+  ],
+};
+
+export default INTRODUCE_DATA;

--- a/src/styles/fonts/Berbas.css
+++ b/src/styles/fonts/Berbas.css
@@ -1,0 +1,7 @@
+@charset "utf-8";
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
+
+@font-face {
+  font-family: 'Bebas Neue', cursive;
+  src: url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
+}

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -17,7 +17,7 @@ const Color = {
   light: lightTheme,
 };
 
-const mode = 'light' || 'dark';
+const mode = 'dark' || 'light';
 
 export const colors = Color[mode];
 


### PR DESCRIPTION
## 세부 사항
<img width="800" alt="스크린샷 2023-03-26 오후 8 53 41" src="https://user-images.githubusercontent.com/77766769/227774067-8b7068a4-e4df-4dab-ac4d-a4991ffabd16.png">
<img width="235" alt="스크린샷 2023-03-26 오후 8 53 47" src="https://user-images.githubusercontent.com/77766769/227774072-7c6c2e96-803a-4285-83a8-f74da9918b6c.png">

- `Introduce` 영역 UI 구현
 - `width` 100%로 설정하여 추후 `layout` 컴포넌트에 바로 적용 용이
 - 버튼 hover시 하이라이트 색상으로 변경
 - 공용컴포넌트`Divider`, `StackButton` 추가
   - `Divider` 마진/두께 props 세팅 => 기본 60px/2px
   - `StackButton` url 및 children 세팅
- 다크모드 대비 `theme` 활용 스타일링
- `introduceData`에서 mock 데이타 작성 및 연동

## 기타 질문 및 특이 사항
- `StackButton` url이 없을시 새창으로 이어지지는 않는데 시멘틱적으로 맞는지 고민입니다.
  - Ruseme를 보여주는 경우에는 url이 필요하지만 skills 같은 곳에서도 공통으로 사용할려면 div 또는 p 가 적합한게 아닐지 고민
    -  그렇다면 a, p 테그를 교차로 보여주는게 맞을지
  - 아니면 url이 없으면 페이지 이동은 하지 않으니 그냥 둘지 의견 부탁드립니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
