### PR TITLE
feat: add Footer component

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+const name = 'NAME';
+const link = '#';
+
+const Footer = () => {
+  return (
+    <FooterWrapper>
+      <Contents>
+        <Texts>
+          © 2023 <NameLink href={link}>{name}</NameLink>_ALL RIGHTS RESERVED.
+        </Texts>
+        <Texts>MADE BY_IN N OUT</Texts>
+      </Contents>
+    </FooterWrapper>
+  );
+};
+
+const FooterWrapper = styled.footer`
+  width: 100%;
+  padding: 3.5rem 6.6rem;
+  /**TODO: 추후 머지된 BACKGROUND_SUB로 변경
+   */
+  background-color: rgba(217, 217, 217, 0.2);
+  font-family: 'Bebas Neue', cursive;
+`;
+
+const Contents = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Texts = styled.p`
+  font-size: 2.4rem;
+`;
+
+const NameLink = styled.a`
+  color: ${({ theme }) => theme.colors.HIGHTLIGHT};
+`;
+
+export default Footer;

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import Footer from './Footer';
+
 import Header from '@/components/common/Header';
 import SideNav from '@/components/common/SideNav';
 
@@ -15,6 +17,7 @@ const Layout = ({ children }: LayoutProps) => {
         <SideNav />
         <SectionWrapper>{children}</SectionWrapper>
       </MainWrapper>
+      <Footer />
     </>
   );
 };


### PR DESCRIPTION
## 세부 사항

- Layout에 Footer를 추가했습니다.
- 구현 화면은 다음과 같습니다.
   <img width="1440" alt="image" src="https://user-images.githubusercontent.com/47904304/231757914-16c7e505-0721-4311-893c-39a493135e83.png">
- NAME 영역은 클릭시 이동할 수 있는 링크를 추가하면 좋을 것 같아 a tag로 감싸줬습니다.([Daum 페이지 ](https://www.daum.net/)footer 참고)

## 기타 질문 및 특이 사항

- Portfolio에 추가해둔 BACKGROUND_SUB로 수정 예정입니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
